### PR TITLE
Add use-service to master role

### DIFF
--- a/puppetstein.rb
+++ b/puppetstein.rb
@@ -244,9 +244,9 @@ end
 
 def create_host_config(hosts, config)
   if hosts[0].hostname && hosts[1].hostname
-    targets = "#{hosts[0].flavor}#{hosts[0].version}-64a{hostname=#{hosts[0].hostname}}-#{hosts[1].flavor}#{hosts[1].version}-64m{hostname=#{hosts[1].hostname}}"
+    targets = "#{hosts[0].flavor}#{hosts[0].version}-64a{hostname=#{hosts[0].hostname}}-#{hosts[1].flavor}#{hosts[1].version}-64m{hostname=#{hosts[1].hostname}\,use-service=true}"
   else
-    targets = "#{hosts[0].flavor}#{hosts[0].version}-64a-#{hosts[1].flavor}#{hosts[1].version}-64m"
+    targets = "#{hosts[0].flavor}#{hosts[0].version}-64a-#{hosts[1].flavor}#{hosts[1].version}-64m{use-service=true}"
   end
 
   cli = BeakerHostGenerator::CLI.new([targets, '--disable-default-role', '--osinfo-version', '1'])


### PR DESCRIPTION
This commit adds `use-service=true` to the master role. This value
is required for the `with_puppet_running_on` beaker method to use
the deployed `puppetserver` instance as the master rather than
attempting to spin up a passenger based master.

In the `puppet` aio acceptance task, this setting is applied with
[this pre-suite](https://github.com/puppetlabs/puppet/blob/master/acceptance/setup/aio/pre-suite/045_EnsureMasterStartedOnPassenger.rb).
This commit is intended to bring the puppetstein bootstrapping
process in parity with that step.
